### PR TITLE
Change the interface of MYTableViewCell.init

### DIFF
--- a/Example/MYTableViewManager.xcodeproj/project.pbxproj
+++ b/Example/MYTableViewManager.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 		86B1FFD01A6568F1000E3772 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = "Le Van Nghia";
 				TargetAttributes = {

--- a/Source/MYTableViewCell.swift
+++ b/Source/MYTableViewCell.swift
@@ -24,7 +24,7 @@ public class MYCellModel : MYViewModel {
         }
     }
     
-    public init<T: MYTableViewCell>(cell: T.Type, height: CGFloat = 44, selectionHandler: MYSelectionHandler? = nil) {
+    public init(cell: MYTableViewCell.Type, height: CGFloat = 44, selectionHandler: MYSelectionHandler? = nil) {
         self.identifier = cell.reuseIdentifier ?? ""
         
         super.init(selectionHandler: selectionHandler)


### PR DESCRIPTION
Using generics arguments as before the change(`public init<T: MYTableViewCell>(cell: T.Type, height: CGFloat = 44, selectionHandler: MYSelectionHandler? = nil)`), it causes build errors when subclassing `MYTableViewCell`.
