### PR TITLE
Set cell size before configuring cell

### DIFF
--- a/Source/Hakuba.swift
+++ b/Source/Hakuba.swift
@@ -222,6 +222,7 @@ extension Hakuba : UITableViewDelegate {
                 heightCalculationCells[cellModel.identifier] = tableView.dequeueReusableCellWithIdentifier(cellModel.identifier) as? MYTableViewCell
             }
             if let cell = heightCalculationCells[cellModel.identifier] {
+                cell.bounds = CGRectMake(0, 0, tableView.bounds.width, cell.bounds.height)
                 cell.configureCell(cellModel)
                 cellModel.calculatedHeight = calculateHeightForConfiguredSizingCell(cell)
                 return cellModel.calculatedHeight!


### PR DESCRIPTION
This can help in situations where the size of the cell in your nib is
different than when actually loaded.
