### PR TITLE
Fix 'Invalid update' crash when removing all cells in tableview.

### DIFF
--- a/Hakuba.podspec
+++ b/Hakuba.podspec
@@ -1,15 +1,15 @@
+
 Pod::Spec.new do |s|
   s.name         = "Hakuba"
   s.version      = "1.3.1"
   s.summary      = "A new way to manage UITableView"
-  s.homepage     = "https://github.com/nghialv/Hakuba"
+  s.homepage     = "https://github.com/beng341/Hakuba"
   s.license      = { :type => "MIT", :file => "LICENSE" }
-  s.author             = { "Le Van Nghia" => "nghialv2607@gmail.com" }
-  s.social_media_url   = "https://twitter.com/nghialv2607"
+  s.authors             = { "Le Van Nghia" => "nghialv2607@gmail.com", "Ben Armstrong" => "beng341+github@gmail.com" }
 
   s.platform     = :ios
   s.ios.deployment_target = "8.0"
-  s.source       = { :git => "https://github.com/nghialv/Hakuba.git", :tag => "1.3.1" }
+  s.source       = { :git => "https://github.com/beng341/Hakuba.git", :tag => "1.3.1" }
   s.source_files  = "Source/*"
   s.requires_arc = true
 end

--- a/Hakuba.podspec
+++ b/Hakuba.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "Hakuba"
-  s.version      = "1.3.1"
+  s.version      = "1.3.2"
   s.summary      = "A new way to manage UITableView"
   s.homepage     = "https://github.com/beng341/Hakuba"
   s.license      = { :type => "MIT", :file => "LICENSE" }

--- a/Source/Hakuba.swift
+++ b/Source/Hakuba.swift
@@ -71,6 +71,7 @@ public class Hakuba : NSObject {
         heightCalculationCells = [:]
         currentTopSection = 0
         willFloatingSection = -1
+        tableView?.reloadData()
         return self
     }
     

--- a/Source/Hakuba.swift
+++ b/Source/Hakuba.swift
@@ -43,7 +43,7 @@ public class Hakuba : NSObject {
     private var heightCalculationCells: [String: MYTableViewCell] = [:]
     private var currentTopSection = 0
     private var willFloatingSection = -1
-    private var insertedSectionsRange: (Int, Int) = (100, -1)
+    private var insertedSectionsRange: (Int, Int) = (1000, -1)
     
     // inserting or deleting rows
     public var cellEditable = false
@@ -115,7 +115,7 @@ public class Hakuba : NSObject {
         let length = insertedSectionsRange.1 - insertedSectionsRange.0
         if length > 0 {
             let insertSet: NSIndexSet =  NSIndexSet(indexesInRange: NSMakeRange(insertedSectionsRange.0, length))
-            insertedSectionsRange = (100, -1)
+            insertedSectionsRange = (1000, -1)
             tableView?.insertSections(insertSet, withRowAnimation: animation)
             return true
         }
@@ -146,7 +146,7 @@ public extension Hakuba {
     func slide(animation: MYAnimation = .None) -> Self {
         // TODO : implementation
         tableView?.reloadData()
-        insertedSectionsRange = (100, -1)
+        insertedSectionsRange = (1000, -1)
         // reset all section reload tracker
         for sec in sections {
             sec.didReloadTableView()


### PR DESCRIPTION
When implementing a SearchBar and updating the results, a crash occurs with the message:

"Invalid update: invalid number of sections.  The number of sections contained in the table view after the update must be equal to the number of sections contained in the table view before the update, plus or minus the number of sections inserted or deleted."
